### PR TITLE
Add a 'compile-only' feature and implement for x86_64.

### DIFF
--- a/cpufeatures/Cargo.toml
+++ b/cpufeatures/Cargo.toml
@@ -14,6 +14,10 @@ categories = ["no-std"]
 edition = "2018"
 readme = "README.md"
 
+[features]
+default = []
+compile-only = []
+
 [target.aarch64-apple-darwin.dependencies]
 libc = "0.2.97"
 

--- a/cpufeatures/src/x86.rs
+++ b/cpufeatures/src/x86.rs
@@ -14,11 +14,11 @@ macro_rules! __unless_target_features {
     ($($tf:tt),+ => $body:expr ) => {{
         #[cfg(not(all($(target_feature=$tf,)*)))]
         {
-            #[cfg(not(target_env = "sgx"))]
+            #[cfg(not(any(target_env = "sgx", feature = "compile-only")))]
             $body
 
             // CPUID is not available on SGX targets
-            #[cfg(target_env = "sgx")]
+            #[cfg(any(target_env = "sgx", feature = "compile-only"))]
             false
         }
 


### PR DESCRIPTION
This is a draft PR which adds a "compile-only" feature to the RustCrypto/cpufeatures crate. The intent here is to use this as a fork to handle CPU features in the SGX enclave.